### PR TITLE
fix(platform): WASM yield point + native HashMap restore

### DIFF
--- a/platform/script/src/value_map.rs
+++ b/platform/script/src/value_map.rs
@@ -2,19 +2,27 @@ use crate::makepad_live_id::LiveId;
 
 use std::ops::{Index, IndexMut};
 
-// Replaced HashMap with Vec to work around an LLVM wasm32 codegen bug that
-// miscompiles both HashMap::insert and BTreeMap internal navigation, silently
-// dropping keys during Makepad's DSL evaluation. Vec + linear scan is immune
-// because it uses only array indexing and equality comparison — operations too
-// simple for LLVM to miscompile. Performance is equivalent for the small maps
-// used here (typically 3-57 entries).
+// On wasm32, we use Vec<(K,V)> to work around an LLVM wasm32 codegen bug that
+// miscompiles HashMap::insert, silently dropping keys during Makepad's DSL
+// evaluation. Vec + linear scan is immune because it uses only array indexing
+// and equality comparison — operations too simple for LLVM to miscompile.
+// Performance is equivalent for the small maps used here (typically 3-57 entries).
 // See: https://github.com/dalbrecht/makepad/issues/6
+//
+// On native targets (x86, ARM), HashMap is used for O(1) lookups since the LLVM
+// codegen bug does not affect these architectures.
 
 #[derive(Clone, Debug)]
 pub struct ValueMap<K, V> {
+    #[cfg(target_arch = "wasm32")]
     entries: Vec<(K, V)>,
+    #[cfg(not(target_arch = "wasm32"))]
+    entries: std::collections::HashMap<K, V>,
 }
 
+// --- Default impl ---
+
+#[cfg(target_arch = "wasm32")]
 impl<K, V> Default for ValueMap<K, V>
 where
     K: Eq + Copy + From<LiveId> + std::fmt::Debug,
@@ -26,6 +34,21 @@ where
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+impl<K, V> Default for ValueMap<K, V>
+where
+    K: Eq + Copy + std::hash::Hash + From<LiveId> + std::fmt::Debug,
+{
+    fn default() -> Self {
+        Self {
+            entries: std::collections::HashMap::new(),
+        }
+    }
+}
+
+// --- Core methods: wasm32 (Vec backend) ---
+
+#[cfg(target_arch = "wasm32")]
 impl<K: Eq + Copy, V> ValueMap<K, V> {
     pub fn get(&self, key: &K) -> Option<&V> {
         for (k, v) in &self.entries {
@@ -103,16 +126,83 @@ impl<K: Eq + Copy, V> ValueMap<K, V> {
     }
 }
 
+// --- Core methods: native (HashMap backend) ---
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<K: Eq + Copy + std::hash::Hash, V> ValueMap<K, V> {
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.entries.get(key)
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.entries.get_mut(key)
+    }
+
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.entries.insert(key, value)
+    }
+
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        self.entries.remove(key)
+    }
+
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.entries.contains_key(key)
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.entries.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&K, &mut V)> {
+        self.entries.iter_mut()
+    }
+
+    pub fn entry(&mut self, key: K) -> VecMapEntry<'_, K, V> {
+        match self.entries.entry(key) {
+            std::collections::hash_map::Entry::Occupied(occ) => {
+                VecMapEntry::Occupied(OccupiedEntry { inner: occ })
+            }
+            std::collections::hash_map::Entry::Vacant(vac) => {
+                VecMapEntry::Vacant(VacantEntry { inner: vac })
+            }
+        }
+    }
+}
+
+// --- Entry types ---
+
 pub enum VecMapEntry<'a, K, V> {
     Occupied(OccupiedEntry<'a, K, V>),
     Vacant(VacantEntry<'a, K, V>),
 }
 
+// --- OccupiedEntry ---
+
+#[cfg(target_arch = "wasm32")]
 pub struct OccupiedEntry<'a, K, V> {
     entries: &'a mut Vec<(K, V)>,
     index: usize,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub struct OccupiedEntry<'a, K: 'a, V: 'a> {
+    inner: std::collections::hash_map::OccupiedEntry<'a, K, V>,
+}
+
+#[cfg(target_arch = "wasm32")]
 impl<'a, K, V> OccupiedEntry<'a, K, V> {
     pub fn get_mut(&mut self) -> &mut V {
         &mut self.entries[self.index].1
@@ -123,11 +213,31 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+impl<'a, K, V> OccupiedEntry<'a, K, V> {
+    pub fn get_mut(&mut self) -> &mut V {
+        self.inner.get_mut()
+    }
+
+    pub fn remove(self) -> V {
+        self.inner.remove()
+    }
+}
+
+// --- VacantEntry ---
+
+#[cfg(target_arch = "wasm32")]
 pub struct VacantEntry<'a, K, V> {
     entries: &'a mut Vec<(K, V)>,
     key: K,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+pub struct VacantEntry<'a, K: 'a, V: 'a> {
+    inner: std::collections::hash_map::VacantEntry<'a, K, V>,
+}
+
+#[cfg(target_arch = "wasm32")]
 impl<'a, K, V> VacantEntry<'a, K, V> {
     pub fn insert(self, value: V) -> &'a mut V {
         self.entries.push((self.key, value));
@@ -136,6 +246,16 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+impl<'a, K: 'a, V: 'a> VacantEntry<'a, K, V> {
+    pub fn insert(self, value: V) -> &'a mut V {
+        self.inner.insert(value)
+    }
+}
+
+// --- Index / IndexMut ---
+
+#[cfg(target_arch = "wasm32")]
 impl<K, V> Index<K> for ValueMap<K, V>
 where
     K: Eq + Copy + From<LiveId>,
@@ -146,9 +266,31 @@ where
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+impl<K, V> Index<K> for ValueMap<K, V>
+where
+    K: Eq + Copy + std::hash::Hash + From<LiveId>,
+{
+    type Output = V;
+    fn index(&self, index: K) -> &Self::Output {
+        self.get(&index).unwrap()
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 impl<K, V> IndexMut<K> for ValueMap<K, V>
 where
     K: Eq + Copy + From<LiveId>,
+{
+    fn index_mut(&mut self, index: K) -> &mut Self::Output {
+        self.get_mut(&index).unwrap()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<K, V> IndexMut<K> for ValueMap<K, V>
+where
+    K: Eq + Copy + std::hash::Hash + From<LiveId>,
 {
     fn index_mut(&mut self, index: K) -> &mut Self::Output {
         self.get_mut(&index).unwrap()

--- a/platform/src/app_main.rs
+++ b/platform/src/app_main.rs
@@ -176,6 +176,7 @@ macro_rules! app_main {
                     }
                 },
             ))));
+            cx.borrow_mut().init_script_vm();
             let studio_http = $crate::resolve_studio_http();
             cx.borrow_mut().init_websockets(&studio_http);
             if $crate::should_run_stdin_loop_from_env() {
@@ -248,6 +249,7 @@ macro_rules! app_main {
                         <dyn AppMain>::handle_event(app, cx, event);
                     }
                 })));
+                cx.init_script_vm();
                 cx.init_websockets(&studio_http);
                 cx.init_cx_os();
                 cx
@@ -291,6 +293,7 @@ macro_rules! app_main {
                         <dyn AppMain>::handle_event(app, cx, event);
                     }
                 })));
+                cx.init_script_vm();
                 let studio_http = $crate::resolve_studio_http();
                 cx.init_websockets(&studio_http);
                 cx.init_cx_os();
@@ -345,6 +348,12 @@ macro_rules! app_main {
         #[cfg(target_arch = "wasm32")]
         pub unsafe extern "C" fn wasm_process_msg(msg_ptr: u32, cx_ptr: u32) -> u32 {
             let cx = &mut *(cx_ptr as *mut Cx);
+            // Lazy-init the Script VM on the first event pump. This runs AFTER
+            // wasm_create_app() has returned and Chrome's event loop has yielded,
+            // avoiding the main-thread hang for large WASM binaries.
+            if cx.script_vm.is_none() {
+                cx.init_script_vm();
+            }
             cx.process_to_wasm(msg_ptr)
         }
 

--- a/platform/src/cx.rs
+++ b/platform/src/cx.rs
@@ -350,19 +350,6 @@ impl Cx {
             SignalToUI::set_ui_signal();
         })));
 
-        let mut script_std = makepad_script_std::ScriptStd::with_network_runtime(net.clone());
-        let mut script_host = 0;
-        let mut vm = ScriptVm {
-            host: &mut script_host,
-            std: &mut script_std,
-            bx: Box::new(ScriptVmBase::new()),
-        };
-
-        //todo!();
-        crate::script::script_mod(&mut vm);
-        let script_vm = std::mem::replace(&mut vm.bx, Box::new(ScriptVmBase::empty()));
-        drop(vm);
-
         Self {
             package_root: None,
             demo_time_repaint: false,
@@ -446,16 +433,40 @@ impl Cx {
             widget_snapshot_callback: None,
             net,
 
-            script_data: CxScriptData {
-                std: script_std,
-                crate_manifests: script_vm.code.crate_manifests.clone(),
-                live_reload: crate::live_reload::CxLiveReloadState {
-                    script_mod_overrides: script_vm.code.script_mod_overrides.clone(),
-                    ..Default::default()
-                },
+            script_data: CxScriptData::default(),
+            script_vm: None,
+        }
+    }
+
+    /// Initialize the Script VM and populate `script_data`.
+    ///
+    /// This is separated from `Cx::new()` so that on WASM the expensive
+    /// `script_mod()` call can be deferred until the first event-loop pump,
+    /// letting Chrome's event loop regain control after loading the binary.
+    /// On native platforms this is called synchronously right after `Cx::new()`.
+    pub fn init_script_vm(&mut self) {
+        debug_assert!(self.script_vm.is_none(), "init_script_vm() called twice");
+        let mut script_std =
+            makepad_script_std::ScriptStd::with_network_runtime(self.net.clone());
+        let mut script_host = 0;
+        let mut vm = ScriptVm {
+            host: &mut script_host,
+            std: &mut script_std,
+            bx: Box::new(ScriptVmBase::new()),
+        };
+        crate::script::script_mod(&mut vm);
+        let script_vm = std::mem::replace(&mut vm.bx, Box::new(ScriptVmBase::empty()));
+        drop(vm);
+
+        self.script_data = CxScriptData {
+            std: script_std,
+            crate_manifests: script_vm.code.crate_manifests.clone(),
+            live_reload: crate::live_reload::CxLiveReloadState {
+                script_mod_overrides: script_vm.code.script_mod_overrides.clone(),
                 ..Default::default()
             },
-            script_vm: Some(script_vm),
-        }
+            ..Default::default()
+        };
+        self.script_vm = Some(script_vm);
     }
 }


### PR DESCRIPTION
## Summary
- Split `script_mod()` out of `Cx::new()` into `Cx::init_script_vm()` — fixes Chrome main-thread hang for large WASM binaries (#458)
- Restore `HashMap` for `ValueMap` on native targets via `cfg(target_arch)` — O(1) lookups on desktop, Vec workaround preserved for wasm32 (#475)

## Changes
- `platform/src/cx.rs` — extract VM init, add `init_script_vm()` method
- `platform/src/app_main.rs` — eager init on native, lazy init in `wasm_process_msg()` for WASM
- `platform/script/src/value_map.rs` — cfg-conditional backing store (HashMap vs Vec)

## Test plan
- [x] `cargo build -p makepad-example-counter` compiles
- [ ] WASM counter example loads in Chrome without hanging
- [ ] Desktop app behavior unchanged